### PR TITLE
Fix

### DIFF
--- a/Dutch/main/Settings.apk/res/values-nl/strings.xml
+++ b/Dutch/main/Settings.apk/res/values-nl/strings.xml
@@ -2045,7 +2045,7 @@ Selecteer het OS van uw computer:"</string>
   <string name="other_sound_settings">Andere geluiden</string>
   <string name="overlay_display_devices_title">Secundaire beeldschermen simuleren</string>
   <string name="owner_info_settings_edit_text_hint">Bijv. Joe’s Android.</string>
-  <string name="owner_info_settings_summary">Geen</string>
+  <string name="owner_info_settings_summary"/>
   <string name="owner_info_settings_title">Eigenaarsgegevens</string>
   <string name="packages_subtitle">Bijgeleverde pakketten</string>
   <string name="page_layout_1">Zon, 16 Augustus</string>


### PR DESCRIPTION
Text incorrectly remains "geen" even though data is set. Other languages also have an empty value here.